### PR TITLE
ecs-local bump

### DIFF
--- a/Formula/ecs-local.rb
+++ b/Formula/ecs-local.rb
@@ -1,9 +1,9 @@
 class EcsLocal < Formula
   desc "Run ECS task definitions locally"
   homepage "https://github.com/Fullscreen/ecs-local"
-  url "https://github.com/Fullscreen/ecs-local/releases/download/0.0.7/darwin_amd64.zip"
-  version "0.0.7"
-  sha256 "462dab74a2ee26b18714fa893f1c40d0a2ae00c3d6423fa5fcc099be3e5fc3f3"
+  url "https://github.com/Fullscreen/ecs-local/releases/download/0.1.1/ecs-local_Darwin_x86_64.tar.gz"
+  version "0.1.1"
+  sha256 "164181f3f2c44fe6ff9d369fc7d95520a0f8c5616b4c121b1d67471ec441be84"
 
   def install
     bin.install "ecs-local"


### PR DESCRIPTION
ecs-local bump to version 0.1.1 which now uses modules and goreleaser